### PR TITLE
Set Codeowners to @arenadata/python-qa

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 
-* @arenadata/qa
+* @arenadata/python-qa


### PR DESCRIPTION
Set Codeowners to @arenadata/python-qa so that Java QA will not be disturbed with the review requests