### PR TITLE
QA-162 use pytest.ini instead of pyproject.toml config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,12 @@ exclude = '''
       \.git
     | \.venv
     | /__pycache__
-    | /data
-    | /docs
-    | /spec
-    | /build
-    | /dist
-    | /venv
+    | /data/
+    | /docs/
+    | /spec/
+    | /build/
+    | /dist/
+    | /venv/
 )
 '''
 

--- a/src/pytest_allure_spec_coverage/config_provider.py
+++ b/src/pytest_allure_spec_coverage/config_provider.py
@@ -13,28 +13,20 @@
 """Plugin config provider"""
 from dataclasses import dataclass
 from functools import cached_property
-from pathlib import Path
-from typing import ClassVar, Mapping
-
-import toml
-from _pytest.config import UsageError
+from _pytest.config import Config
 
 
 @dataclass
 class ConfigProvider:
-    """Provides config for the plugin via parsing pyproject.toml file"""
+    """Provides config for the plugin from pytest config object"""
 
-    TOOL_KEY: ClassVar[str] = "pytest_allure_spec_coverage"
-    FILENAME: ClassVar[str] = "pyproject.toml"
+    pytest_config: Config
 
-    path_to_config_file: Path
+    def get(self, name: str):
+        """Get option by name"""
+        return self.pytest_config.getini(name)
 
     @cached_property
-    def config(self) -> Mapping:
-        """Read all params related to pytest_allure_spec_coverage from pyproject.toml"""
-
-        try:
-            config = toml.load(self.path_to_config_file / self.FILENAME)
-            return config.get("tool", {}).get(self.TOOL_KEY, {})
-        except FileNotFoundError as ex:
-            raise UsageError(f"Unable to load configuration file {self.path_to_config_file}") from ex
+    def root(self):
+        """Get config root path"""
+        return self.pytest_config.rootpath

--- a/src/pytest_allure_spec_coverage/config_provider.py
+++ b/src/pytest_allure_spec_coverage/config_provider.py
@@ -12,7 +12,6 @@
 
 """Plugin config provider"""
 from dataclasses import dataclass
-from functools import cached_property
 from _pytest.config import Config
 
 
@@ -26,7 +25,6 @@ class ConfigProvider:
         """Get option by name"""
         return self.pytest_config.getini(name)
 
-    @cached_property
     def root(self):
         """Get config root path"""
         return self.pytest_config.rootpath

--- a/src/pytest_allure_spec_coverage/models/collector.py
+++ b/src/pytest_allure_spec_coverage/models/collector.py
@@ -12,8 +12,11 @@
 """Abstract collector"""
 
 from abc import ABC, abstractmethod
-from typing import List, Mapping
+from typing import List
 
+from _pytest.config.argparsing import Parser
+
+from pytest_allure_spec_coverage.config_provider import ConfigProvider
 from pytest_allure_spec_coverage.models.scenario import Scenario
 
 
@@ -22,7 +25,7 @@ class Collector(ABC):
     Abstract collector
     """
 
-    def __init__(self, config: Mapping):
+    def __init__(self, config: ConfigProvider):
         self.config = config
         self.setup_config()
 
@@ -42,3 +45,8 @@ class Collector(ABC):
         Raises:
             ValueError: if config validation fails
         """
+
+    @staticmethod
+    @abstractmethod
+    def addoption(parser: Parser):
+        """Implementation of pytest_addoption hook"""

--- a/src/pytest_allure_spec_coverage/plugin.py
+++ b/src/pytest_allure_spec_coverage/plugin.py
@@ -11,9 +11,8 @@
 # limitations under the License.
 
 """Main plugin module"""
-
-from pathlib import Path
-from typing import MutableMapping, Optional, Type
+import dataclasses
+from typing import MutableMapping, Optional, Type, Iterable
 
 import pytest
 from _pytest.config import Config
@@ -43,19 +42,28 @@ def pytest_addoption(parser: Parser) -> None:
     """Register plugin options"""
 
     parser.addoption("--sc-type", action="store", type=str, help="Spec collector type string identifier")
-    parser.addoption(
-        "--sc-cfgpath",
-        action="store",
-        type=Path,
-        default=Path(),
-        help="Path to spec collector configuration file",
+    parser.addini(
+        "allure_labels", "What labels to use for spec tree. Example: epic, feature, story", type="linelist", default=[]
     )
+    parser.addini("link_label", "What link label to be", type="string", default="Scenario")
 
 
 def pytest_register_spec_collectors(collectors: CollectorsMapping) -> None:
     """Register available spec collectors"""
 
     collectors["sphinx"] = SphinxCollector
+
+
+@dataclasses.dataclass(eq=False)
+class CollectorsPlugin:
+    """Simple plugin to register all collector options"""
+
+    collectors: Iterable[Type[Collector]]
+
+    def pytest_addoption(self, parser: Parser) -> None:
+        """Register plugin options"""
+        for collector in self.collectors:
+            collector.addoption(parser)
 
 
 @pytest.hookimpl(trylast=True)
@@ -70,15 +78,16 @@ def pytest_configure(config: Config) -> None:
         None,
     )
 
+    collectors: CollectorsMapping = {}
+    config.hook.pytest_register_spec_collectors(collectors=collectors)
+    config.pluginmanager.register(CollectorsPlugin(collectors=collectors.values()))
+
     if not listener or not config.option.sc_type:
         return
 
-    collectors: CollectorsMapping = {}
-    config.hook.pytest_register_spec_collectors(collectors=collectors)
     if config.option.sc_type not in collectors.keys():
         raise UsageError(f"Unexpected collector type, registered ones: {collectors.keys()}")
+    cfg_provider = ConfigProvider(pytest_config=config)
     sc_type = collectors[config.option.sc_type]
-    cfg_provider = ConfigProvider(config.option.sc_cfgpath)
-    collector: Collector = sc_type(config=cfg_provider.config)
-    matcher = ScenariosMatcher(config=cfg_provider.config, reporter=listener.allure_logger, collector=collector)
+    matcher = ScenariosMatcher(config=cfg_provider, reporter=listener.allure_logger, collector=sc_type)
     config.pluginmanager.register(matcher, ScenariosMatcher.PLUGIN_NAME)

--- a/src/pytest_allure_spec_coverage/plugin.py
+++ b/src/pytest_allure_spec_coverage/plugin.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 
 """Main plugin module"""
-import dataclasses
+from dataclasses import dataclass
 from typing import MutableMapping, Optional, Type, Iterable
 
 import pytest
@@ -54,7 +54,7 @@ def pytest_register_spec_collectors(collectors: CollectorsMapping) -> None:
     collectors["sphinx"] = SphinxCollector
 
 
-@dataclasses.dataclass(eq=False)
+@dataclass(eq=False)
 class CollectorsPlugin:
     """Simple plugin to register all collector options"""
 

--- a/src/pytest_allure_spec_coverage/spec_collectors/sphinx.py
+++ b/src/pytest_allure_spec_coverage/spec_collectors/sphinx.py
@@ -13,6 +13,8 @@
 import os
 import warnings
 from typing import Optional
+
+from _pytest.config.argparsing import Parser
 from docutils.core import publish_doctree
 from docutils.utils import SystemMessage
 
@@ -42,15 +44,30 @@ class SphinxCollector(Collector):
     spec_endpoint: Optional[str]
     default_branch: str
 
+    @staticmethod
+    def addoption(parser: Parser):
+        parser.addini("sphinx_dir", help="Directory with the .rst scenarios", type="string")
+        parser.addini(
+            "spec_endpoint",
+            help="Where is hosted your scenarios. Need to form scenario link. Optionally",
+            type="string",
+            default=None,
+        )
+        parser.addini(
+            "default_branch", help="Need to form scenario link. 'master' by default", type="string", default="master"
+        )
+
     def setup_config(self):
-        if not (sphinx_dir := self.config.get("sphinx-dir")):  # pylint: disable = superfluous-parens
-            raise ValueError("Option sphinx-dir is required")
+        if not (sphinx_dir := self.config.get("sphinx_dir")):  # pylint: disable = superfluous-parens
+            raise ValueError("Option sphinx_dir is required")
+        if not os.path.isabs(sphinx_dir):
+            sphinx_dir = os.path.join(self.config.root, sphinx_dir)
         if not os.path.exists(sphinx_dir):
             raise ValueError(f"Directory with sphinx specs {sphinx_dir} doesn't exists")
 
         self.sphinx_dir = sphinx_dir
-        self.spec_endpoint = self.config.get("spec-endpoint")
-        self.default_branch = self.config.get("default-branch", "master")
+        self.spec_endpoint = self.config.get("spec_endpoint")
+        self.default_branch = self.config.get("default_branch")
 
     def collect(self):
         branch = os.getenv("BRANCH_NAME")


### PR DESCRIPTION
Now collectors and matcher options are registered as pytestini opts and will be shown on pytest --help output
It means that config parsing logic will occur through pytest. Pyproject.toml support will still be support, but with [tool.pytest.ini_options] table

Options format again changed to `shpinx_dir` because all pytest options are in this format