### PR TITLE
QA-248 add --sc-only option

### DIFF
--- a/src/pytest_allure_spec_coverage/config_provider.py
+++ b/src/pytest_allure_spec_coverage/config_provider.py
@@ -29,3 +29,8 @@ class ConfigProvider:
     def root(self):
         """Get config root path"""
         return self.pytest_config.rootpath
+
+    @property
+    def fail_under(self):
+        """Fail if spec coverage less than value"""
+        return self.pytest_config.option.sc_only and self.pytest_config.option.sc_target

--- a/src/pytest_allure_spec_coverage/config_provider.py
+++ b/src/pytest_allure_spec_coverage/config_provider.py
@@ -33,4 +33,5 @@ class ConfigProvider:
     @property
     def fail_under(self):
         """Fail if spec coverage less than value"""
+        # pylint: disable=no-member
         return self.pytest_config.option.sc_only and self.pytest_config.option.sc_target

--- a/src/pytest_allure_spec_coverage/matcher.py
+++ b/src/pytest_allure_spec_coverage/matcher.py
@@ -334,7 +334,7 @@ class ScenariosMatcher:
         if self.config.fail_under and self.spec_coverage_percent < self.config.fail_under:
             pytest.exit(
                 f"Spec coverage percent is {self.spec_coverage_percent}, "
-                f"but is less than target {self.config.fail_under}",
+                f"and it is less than target {self.config.fail_under}",
                 returncode=ExitCode.NO_TESTS_COLLECTED,
             )
 
@@ -352,4 +352,4 @@ class ScenariosMatcher:
         yield
         if self.config.fail_under and exitstatus != ExitCode.NO_TESTS_COLLECTED:
             terminal = session.config.pluginmanager.get_plugin("terminalreporter")
-            terminal.write_line(f"Spec coverage greater than target {self.config.fail_under}. 🎉🎉🎉")
+            terminal.write_line(f"Spec coverage is greater than target {self.config.fail_under}! 🎉🎉🎉")

--- a/src/pytest_allure_spec_coverage/matcher.py
+++ b/src/pytest_allure_spec_coverage/matcher.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 import pytest
+from _pytest.config import ExitCode
 from _pytest.main import Session
 from _pytest.nodes import Item
 from _pytest.terminal import TerminalReporter
@@ -191,6 +192,11 @@ class ScenariosMatcher:
             if not pytest_items.selected and pytest_items.deselected
         )
 
+    @property
+    def spec_coverage_percent(self):
+        """Coverage percent"""
+        return int((len(self.scenarios) - len(tuple(self.missed))) / len(self.scenarios) * 100)
+
     def match(self, items: List[pytest.Item], deselected=False) -> None:
         """Match collected tests items with its scenarios"""
 
@@ -318,12 +324,32 @@ class ScenariosMatcher:
         """Collect deselected tests cases"""
         self.match(items, deselected=True)
 
+    @pytest.hookimpl(hookwrapper=True, trylast=True)
+    def pytest_collection_finish(self):
+        """
+        This hook exit pytest if need to check coverage percent
+        Important that fail will be after terminal reporting hooks
+        """
+        yield
+        if self.config.fail_under and self.spec_coverage_percent < self.config.fail_under:
+            pytest.exit(
+                f"Spec coverage percent is {self.spec_coverage_percent}, "
+                f"but is less than target {self.config.fail_under}",
+                returncode=ExitCode.NO_TESTS_COLLECTED,
+            )
+
     def pytest_terminal_summary(self, terminalreporter: TerminalReporter):
         """
         Add specification coverage percent to summary stats line
         """
-        spec_coverage_percent = int((len(self.scenarios) - len(tuple(self.missed))) / len(self.scenarios) * 100)
-
         terminalreporter.build_summary_stats_line = _build_summary_stats_line(
-            terminalreporter.build_summary_stats_line, spec_coverage_percent
+            terminalreporter.build_summary_stats_line, self.spec_coverage_percent
         )
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_sessionfinish(self, session, exitstatus):
+        """After terminal summary we print spec coverage success message"""
+        yield
+        if self.config.fail_under and exitstatus != ExitCode.NO_TESTS_COLLECTED:
+            terminal = session.config.pluginmanager.get_plugin("terminalreporter")
+            terminal.write_line(f"Spec coverage greater than target {self.config.fail_under}. 🎉🎉🎉")

--- a/src/pytest_allure_spec_coverage/matcher.py
+++ b/src/pytest_allure_spec_coverage/matcher.py
@@ -333,8 +333,8 @@ class ScenariosMatcher:
         yield
         if self.config.fail_under and self.spec_coverage_percent < self.config.fail_under:
             pytest.exit(
-                f"Spec coverage percent is {self.spec_coverage_percent}, "
-                f"and it is less than target {self.config.fail_under}",
+                f"Spec coverage percent is {self.spec_coverage_percent}%, "
+                f"and it is less than target {self.config.fail_under}%",
                 returncode=ExitCode.NO_TESTS_COLLECTED,
             )
 
@@ -352,4 +352,4 @@ class ScenariosMatcher:
         yield
         if self.config.fail_under and exitstatus != ExitCode.NO_TESTS_COLLECTED:
             terminal = session.config.pluginmanager.get_plugin("terminalreporter")
-            terminal.write_line(f"Spec coverage is greater than target {self.config.fail_under}! 🎉🎉🎉")
+            terminal.write_line(f"Spec coverage is greater than target {self.config.fail_under}%! 🎉🎉🎉")

--- a/tests/_data/sc_only_test.py
+++ b/tests/_data/sc_only_test.py
@@ -1,0 +1,16 @@
+"""Tests for --sc-only option tests"""
+import pytest
+
+
+def test_abandoned_case():
+    """Case without scenario mark"""
+
+
+@pytest.mark.scenario("simple_scenario")
+def test_single_scenario_case():
+    """Case with the single one scenario"""
+
+
+@pytest.mark.scenario("deselected_scenario")
+def test_deselected_scenario_case():
+    """Case that will be deselected but covered scenario"""

--- a/tests/plugin/test_matcher.py
+++ b/tests/plugin/test_matcher.py
@@ -19,6 +19,7 @@ from typing import Collection, List, MutableSequence, Optional, Tuple, Type
 
 import allure
 import pytest
+from _pytest.config import ExitCode
 from _pytest.pytester import Pytester
 
 from pytest_allure_spec_coverage.matcher import ScenariosMatcher, make_allure_labels
@@ -253,6 +254,7 @@ def test_sc_only(pytester: Pytester):
             additional_opts=["--sc-type", "test", "--sc-only"],
             outcomes={"passed": 0},
         )
+        assert pytester_result.ret == ExitCode.NO_TESTS_COLLECTED
         assert "_pytest.outcomes.Exit" in pytester_result.outlines[-1]
         assert "50% specification coverage" in pytester_result.outlines[-2]
     with allure.step("Assert that --sc-target less than coverage"):

--- a/tests/plugin/test_matcher.py
+++ b/tests/plugin/test_matcher.py
@@ -240,3 +240,26 @@ def test_matcher(
     with allure.step("Check summary for coverage percent"):
         percent = (len(scenarios) - len(not_implemented)) * 100 // len(scenarios)
         assert f"{percent}%" in pytester_result.outlines[-1]
+
+
+@pytest.mark.usefixtures("_conftest")
+def test_sc_only(pytester: Pytester):
+    """Test --sc-only and --sc-target options"""
+
+    with allure.step("Assert that --sc-only not running tests"):
+        pytester_result, _ = run_with_allure(
+            pytester=pytester,
+            testfile_path="sc_only_test.py",
+            additional_opts=["--sc-type", "test", "--sc-only"],
+            outcomes={"passed": 0},
+        )
+        assert "_pytest.outcomes.Exit" in pytester_result.outlines[-1]
+        assert "50% specification coverage" in pytester_result.outlines[-2]
+    with allure.step("Assert that --sc-target less than coverage"):
+        pytester_result, _ = run_with_allure(
+            pytester=pytester,
+            testfile_path="sc_only_test.py",
+            additional_opts=["--sc-type", "test", "--sc-only", "--sc-target", "25"],
+            outcomes={"passed": 0},
+        )
+        assert "🎉🎉🎉" in pytester_result.outlines[-1]


### PR DESCRIPTION
Spec collector now can be running as a linter to check that specs coverage is enough
```
============ 3 tests collected, 50% specification coverage in 0.11s ============
! _pytest.outcomes.Exit: Spec coverage percent is 50, but is less than target 100 !
```
```
============ 3 tests collected, 50% specification coverage in 0.01s ============
Spec coverage greater than target 25. 🎉🎉🎉
```