### PR TITLE
Make coverage terminal report operate without allure options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ max-line-length = 120
 max-module-lines = 1000
 
 [tool.isort]
+profile = "black"
 line_length = 120
 
 [tool.pytest.ini_options]

--- a/src/pytest_allure_spec_coverage/common.py
+++ b/src/pytest_allure_spec_coverage/common.py
@@ -1,0 +1,18 @@
+"""Common plugin utilities"""
+
+from typing import Optional
+
+from _pytest.config import Config
+from allure_pytest.listener import AllureListener
+
+
+def allure_listener(config: Config) -> Optional[AllureListener]:
+    """AllureListener plugin instance from pytest.Config"""
+
+    return next(
+        filter(
+            lambda plugin: (isinstance(plugin, AllureListener)),
+            dict(config.pluginmanager.list_name_plugin()).values(),
+        ),
+        None,
+    )

--- a/src/pytest_allure_spec_coverage/matcher.py
+++ b/src/pytest_allure_spec_coverage/matcher.py
@@ -33,7 +33,7 @@ from _pytest.config import ExitCode
 from _pytest.main import Session
 from _pytest.nodes import Item
 from _pytest.terminal import TerminalReporter
-from allure_commons.model2 import Label, Link, Status, TestResult, StatusDetails
+from allure_commons.model2 import Label, Link, Status, StatusDetails, TestResult
 from allure_commons.reporter import AllureReporter
 from allure_commons.types import LabelType, LinkType
 from allure_commons.utils import uuid4
@@ -309,7 +309,7 @@ class ScenariosMatcher:
         """Collect implemented test cases after items collection complete"""
 
         self.match(items)
-        self.mark()
+
         try:
             import xdist  # pylint: disable=import-outside-toplevel
         except ImportError:
@@ -317,7 +317,10 @@ class ScenariosMatcher:
         else:
             if xdist.get_xdist_worker_id(session) not in ["master", "gw0"]:
                 return
-        self.report()
+
+        if self.reporter:
+            self.mark()
+            self.report()
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_deselected(self, items: List[pytest.Item]):


### PR DESCRIPTION
Now for the coverage report in the terminal report, we need to pass `--alluredir` option. But it is not really necessary. Need to remove this dependency.